### PR TITLE
MenuProvider allows other components to respond to menus being open or not

### DIFF
--- a/components/global/MainMenu/index.js
+++ b/components/global/MainMenu/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext } from "react";
+import { useState } from "react";
 import { useRouter } from "next/router";
 import PropTypes from "prop-types";
 import Button from "@/primitives/Button";

--- a/components/global/PrimaryHeader/_styles.scss
+++ b/components/global/PrimaryHeader/_styles.scss
@@ -16,5 +16,14 @@
       fill: functions.palette(white);
     }
   }
+
+  .close-button {
+    opacity: 1;
+    transition: opacity 0.2s ease-out;
+
+    &.menus-open {
+      opacity: 0;
+    }
+  }
 }
 

--- a/components/global/PrimaryHeader/index.jsx
+++ b/components/global/PrimaryHeader/index.jsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useContext, useState } from "react";
+import MenuContext from "@/contexts/Menu";
 import PropTypes from "prop-types";
+import classnames from "classnames";
 import Buttonish from "@/primitives/Buttonish";
 import MainMenu from "@/global/MainMenu";
 import IconComposer from "@/svg/IconComposer";
@@ -9,6 +11,7 @@ import Hamburger from "@/svg/icons/Hamburger";
 const quickAccessItems = [{}];
 
 export default function Header({ closeUrl = "/", route }) {
+  const { menusOpen } = useContext(MenuContext) || {};
   const [isOpen, setIsOpen] = useState(true);
   const [isMenu, setIsMenu] = useState(false);
 
@@ -23,7 +26,9 @@ export default function Header({ closeUrl = "/", route }) {
         icon={<Close />}
         text="Close Explorer"
         isIcon
-        classes="close-button"
+        classes={classnames("close-button", {
+          "menus-open": (menusOpen || []).length > 0,
+        })}
       />
     </header>
   );

--- a/components/layouts/Primary/index.js
+++ b/components/layouts/Primary/index.js
@@ -1,12 +1,16 @@
+import { useState } from "react";
+import { MenuProvider } from "@/contexts/Menu";
 import PropTypes from "prop-types";
 import Header from "@/global/PrimaryHeader";
 
 export default function PrimaryLayout({ closeUrl, route, children }) {
+  const [menusOpen, setMenusOpen] = useState([]);
+
   return (
-    <>
+    <MenuProvider value={{ setMenusOpen, menusOpen }}>
       <Header closeUrl={closeUrl} route={route} />
       {children}
-    </>
+    </MenuProvider>
   );
 }
 

--- a/components/primitives/Menu/index.js
+++ b/components/primitives/Menu/index.js
@@ -1,6 +1,7 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useContext, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
+import MenuContext from "@/contexts/Menu";
 import Button from "@/primitives/Button";
 import IconComposer from "@/svg/IconComposer";
 import useFocusTrap from "@/hooks/useFocusTrap";
@@ -22,6 +23,8 @@ export default function Menu({
   secondaryCloseButton,
   secondaryCloseButtonOpts,
 }) {
+  const { setMenusOpen, menusOpen } = useContext(MenuContext) || {};
+
   const [isOpen, setIsOpen] = useState(
     typeof openOverride === "boolean" ? openOverride : false
   );
@@ -43,18 +46,36 @@ export default function Menu({
     if (isOpenOverride && closeCallback) {
       closeCallback(false);
     } else if (closeCallback) {
-      closeCallback(isOpen);
+      closeCallback(false);
+    }
+
+    if (menusOpen && setMenusOpen) {
+      if (menusOpen.includes(labelledbyId)) {
+        setMenusOpen(
+          menusOpen.filter((menuId, index) => {
+            return menuId !== labelledbyId;
+          })
+        );
+      }
     }
   }
 
   function handleOpen() {
     const isOpenOverride = typeof openOverride === "boolean";
-    if (!isOpenOverride) setIsOpen(true);
+    if (!isOpenOverride) {
+      setIsOpen(true);
+    }
 
     if (isOpenOverride && openCallback) {
       openCallback(true);
-    } else if (closeCallback) {
-      openCallback(isOpen);
+    } else if (openCallback) {
+      openCallback(true);
+    }
+
+    if (menusOpen && setMenusOpen) {
+      if (!menusOpen.includes(labelledbyId)) {
+        setMenusOpen([...menusOpen, labelledbyId]);
+      }
     }
   }
 

--- a/contexts/Menu.js
+++ b/contexts/Menu.js
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+import PropTypes from "prop-types";
+
+const MenuContext = createContext(null);
+
+export const MenuProvider = MenuContext.Provider;
+
+export default MenuContext;


### PR DESCRIPTION
Implemented in PrimaryHeader and Menu components: If there are any modal-type menus open the close button in the PrimaryHeader hides itself to avoid any confusion with having two close buttons in screen (e.g. the one in the header and the one in the modal menu)