### PR TITLE
[EPO-4674] Update client to use custom HiPS staging urls

### DIFF
--- a/components/viewer/Aladin/testData/testHiPSCatalogs.js
+++ b/components/viewer/Aladin/testData/testHiPSCatalogs.js
@@ -1,7 +1,16 @@
+// other working catalog url
+// "https://data.darts.isas.jaxa.jp/pub/judo2/HiPS/SWIFT-BAT_CAT"
+
+// staging catalog url
+// "https://epo-hips.netlify.app/catalog_skyviewer"
+
+// localhost catalog url
+// "http://localhost:5000/catalog"
+
 export default [
   {
     type: "HiPS",
-    url: "https://data.darts.isas.jaxa.jp/pub/judo2/HiPS/SWIFT-BAT_CAT",
+    url: "https://epo-hips.netlify.app/catalog_skyviewer",
     options: {
       // displayLabel: true,
       // labelColumn: "main_id",

--- a/components/viewer/Skyviewer.jsx
+++ b/components/viewer/Skyviewer.jsx
@@ -68,6 +68,23 @@ export default function Skyviewer({
 
   useEffect(() => {
     waitForGlobal("A", () => {
+      const aladin = window.A.aladin(
+        selector,
+        Object.assign(options, {
+          fov,
+          target,
+        })
+      );
+      const customSurvey = aladin.setImageSurvey(
+        aladin.createImageSurvey(
+          "Custom Test",
+          "Custom Test Color",
+          survey,
+          "equatorial",
+          5,
+          { imgFormat: "jpg" }
+        )
+      );
       setAladins({
         // window.A.init.then(() => {
         //   setAladins({
@@ -86,14 +103,7 @@ export default function Skyviewer({
 
         // Initialize aladin Global
         aladinGlobal: window.A,
-        aladin: window.A.aladin(
-          selector,
-          Object.assign(options, {
-            survey,
-            fov,
-            target,
-          })
-        ),
+        aladin,
       });
     });
   }, [selector, survey, fov, target, options]);

--- a/pages/explorer/index.js
+++ b/pages/explorer/index.js
@@ -3,11 +3,19 @@ import PrimaryLayout from "@/layouts/Primary";
 import ExplorerLayout from "@/layouts/Explorer";
 import Skyviewer from "@/viewer/Skyviewer";
 
+// other working survey url
+// http://alasky.u-strasbg.fr/DSS/DSSColor
+// staging survey url
+// "https://epo-hips.netlify.app/images"
+
+// localhost survey url
+// "http://localhost:5000/images"
+
 const Explorer = () => {
   return (
     <Skyviewer
       selector="#aladin-lite-div"
-      survey="P/DSS2/color"
+      survey="http://alasky.u-strasbg.fr/DSS/DSSColor"
       fov={100}
       fovRange={[0.03, 180]}
       target="267.0208333333 -24.7800000000"

--- a/pages/tours/[tour]/tour.js
+++ b/pages/tours/[tour]/tour.js
@@ -3,11 +3,17 @@ import PrimaryLayout from "@/layouts/Primary";
 import ExplorerLayout from "@/layouts/Explorer";
 import Skyviewer from "@/viewer/Skyviewer";
 
+// staging survey url
+// "https://epo-hips.netlify.app/images"
+
+// localhost survey url
+// "http://localhost:5000/images"
+
 const Tour = () => {
   return (
     <Skyviewer
       selector="#aladin-lite-div"
-      survey="P/DSS2/color"
+      survey="https://epo-hips.netlify.app/images"
       fov={100}
       fovRange={[0.03, 180]}
       target="267.0208333333 -24.7800000000"


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4674

## What this change does ##
Builds on @ericdrosas87's work deploying [a custom HiPS server to netlify](epo-hips.netlify.app).  This change hardcodes the urls for staging and leaves comments with urls that will work when working with locally hosted HiPS server, and other orgs' working production HiPS server URLs.  This change is a breaking change.  Trying to use `string` format surveys will no longer work, surveys must be added explicitly with a URL by using the `createImageSurvey` method.