### PR TITLE
[EPo-5184] Goals and Landmarks buttons toggle cats

### DIFF
--- a/components/explorer/Aladin/index.js
+++ b/components/explorer/Aladin/index.js
@@ -69,12 +69,14 @@ export default function Aladin({
     addAladinEventHandlers();
 
     // Update Catalogs
-    if (catalogs) addCatalogs(aladinizeCats(catalogs));
+    if (catalogs && aladin.view.catalogs.length === 0) {
+      addCatalogs(aladinizeCats(catalogs));
+    }
 
     // Update Markers
     // addMarkers(markerLayers);
 
-    if (jpgs) addJpgs(jpgs);
+    // if (jpgs) addJpgs(jpgs);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aladinGlobal, aladin, catalogs, jpgs]);
 
@@ -136,11 +138,11 @@ export default function Aladin({
 
   function toggleLandmarks(show) {
     const cats = aladin.view.catalogs;
-
     const landmarkCats = cats.filter((cat) => {
       const { name } = cat;
       return name === "landmark";
     });
+
     if (landmarkCats.length < 1) return;
 
     landmarkCats.forEach((cat) => {
@@ -151,12 +153,12 @@ export default function Aladin({
 
   function toggleGoals(show) {
     const cats = aladin.view.catalogs;
-
     const goalCats = cats.filter((cat) => {
       const { name } = cat;
 
       return name === "goal";
     });
+
     if (goalCats.length < 1) return;
 
     goalCats.forEach((cat) => {

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -38,3 +38,21 @@ export const getTourData = (id) => {
   tour.pois = PLACEHOLDER_POIS;
   return tour;
 };
+
+export const moveInArray = (arr, from, to) => {
+  // Make sure a valid array is provided
+  if (Object.prototype.toString.call(arr) !== "[object Array]") {
+    throw new Error("Please provide a valid array");
+  }
+
+  // Delete the item from it's current position
+  const item = arr.splice(from, 1);
+
+  // Make sure there's an item to move
+  if (!item.length) {
+    throw new Error("There is no item in the array at index " + from);
+  }
+
+  // Move the item to its new position
+  arr.splice(to, 0, item[0]);
+};

--- a/pages/explorer/index.js
+++ b/pages/explorer/index.js
@@ -3,6 +3,7 @@ import { withLayout } from "@moxy/next-layout";
 import PrimaryLayout from "@/layouts/Primary";
 import AladinLayout from "@/layouts/Aladin";
 import { getCatalogsSurveysData } from "@/lib/api/catalogsSurveys";
+import { moveInArray } from "@/helpers";
 import Explorer from "@/components/explorer/index.js";
 
 const ExplorerPage = ({ catalogs, survey }) => {
@@ -28,6 +29,24 @@ export default withLayout(
 
 export async function getStaticProps() {
   const { catalogs, surveys } = await getCatalogsSurveysData();
+  const lastCatsIndex = catalogs.length - 1;
+  const goalsCatIndex = catalogs.findIndex((cat) => {
+    return cat.title === "goal";
+  });
+
+  const landmarksCatIndex = catalogs.findIndex((cat) => {
+    return cat.title === "landmark";
+  });
+
+  if (landmarksCatIndex >= 0) {
+    moveInArray(catalogs, landmarksCatIndex, lastCatsIndex);
+  }
+
+  if (goalsCatIndex >= 0) {
+    moveInArray(catalogs, goalsCatIndex, lastCatsIndex);
+  }
+
+  // moveInArray();
   return { props: { catalogs, survey: surveys[0] } };
 }
 


### PR DESCRIPTION
Orders landmark and goals cats last in the array to ensure their marker icons are always on top
Does not add Catalogs to Aladin view if catalogs have already been added (i.e. only loads catalogs once)