### PR TITLE
Fix workflow bug

### DIFF
--- a/.github/workflows/dev-pull-request.yaml
+++ b/.github/workflows/dev-pull-request.yaml
@@ -45,16 +45,18 @@ jobs:
       run: docker push gcr.io/${{ secrets.SV_PROJ_NAME }}/skyviewer-client:${{ github.sha }}
 
     - name: Deploy branch-tagged version to App Engine
+      env:
+        BRANCH_NAME: ${{ github.head_ref }}
       run: |-
         gcloud app deploy app.yaml \
         --image-url=gcr.io/${{ secrets.SV_PROJ_NAME }}/skyviewer-client:${{ github.sha }} \
-        --version=${{ github.head_ref }} \
+        --version=${BRANCH_NAME,,} \
         --no-promote \
         --project=${{ secrets.SV_PROJ_NAME }}
     
     - name: Get the version URL
       id: get_version
-      run: echo "version_url=$(gcloud app versions list --uri --service=skyviewer-client --filter=version.id:${{ github.head_ref }})" >> $GITHUB_ENV
+      run: echo "version_url=$(gcloud app versions list --uri --service=skyviewer-client --filter=version.id:${BRANCH_NAME,,})" >> $GITHUB_ENV
 
     - name: Post the URL to the PR
       uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -45,16 +45,20 @@ jobs:
       run: docker push gcr.io/epo-integration-0e42/skyviewer-client:${{ github.sha }}
 
     - name: Deploy branch-tagged version to App Engine
+      env:
+        BRANCH_NAME: ${{ github.head_ref }}
       run: |-
         gcloud app deploy app.yaml \
         --image-url=gcr.io/epo-integration-0e42/skyviewer-client:${{ github.sha }} \
-        --version=${{ github.head_ref }} \
+        --version=${BRANCH_NAME,,} \
         --no-promote \
         --project=epo-integration-0e42
     
     - name: Get the version URL
       id: get_version
-      run: echo "version_url=$(gcloud app versions list --uri --service=skyviewer-client --filter=version.id:${{ github.head_ref }})" >> $GITHUB_ENV
+      env:
+        BRANCH_NAME: ${{ github.head_ref }}
+      run: echo "version_url=$(gcloud app versions list --uri --service=skyviewer-client --filter=version.id:${BRANCH_NAME,,})" >> $GITHUB_ENV
 
     - name: Post the URL to the PR
       uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
This push makes sure that the branch name (which is used as the version name of the GAE service deployment) is passed the gcloud in lowercase to prevent errors.