### PR TITLE
feat: return to initial view

### DIFF
--- a/components/molecules/ExplorerControls/ReturnToInitial/index.tsx
+++ b/components/molecules/ExplorerControls/ReturnToInitial/index.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { FC } from "react";
+import { useReducedMotion } from "motion/react";
+import IconButton from "@/components/atomic/IconButton";
+import { useAladin } from "@/contexts/Aladin";
+import { panAndZoom } from "@/lib/aladin/animation";
+import IconComposer from "@rubin-epo/epo-react-lib/IconComposer";
+import { useTranslation } from "react-i18next";
+
+const ReturnToInital: FC = () => {
+  const { t } = useTranslation();
+  const reduceMotion = useReducedMotion();
+  const { isLoading, aladin, A } = useAladin();
+
+  const onClick = () => {
+    if (!isLoading) {
+      const { options } = aladin;
+      const { fov: initialFov, target } = aladin.options;
+      const initialPosition = target.split(" ").map(parseFloat);
+
+      const [currentFov] = aladin.getFov();
+      const currentPosition = aladin.getRaDec();
+
+      const precision = 1;
+      const current = A.coo(...currentPosition, precision);
+      const initial = A.coo(initialPosition[0], initialPosition[1], precision);
+      current.setFrame(options.cooFrame);
+      initial.setFrame(options.cooFrame);
+
+      if (current.format("d") !== initial.format("d")) {
+        if (reduceMotion) {
+          aladin.setFov(initialFov);
+          aladin.gotoRaDec(initialPosition[0], initialPosition[1]);
+        } else {
+          const middleFov =
+            Math.max(initialFov, currentFov) +
+            Math.abs(initialFov - currentFov) * 0.1;
+
+          const zoomOutTime = Math.min(
+            Math.max(Math.abs(middleFov - currentFov), 0),
+            1
+          );
+          const panTime = Math.min(current.distance(initial), 1.5);
+          const zoomInTime = Math.min(
+            Math.max(Math.abs(middleFov - initialFov), 0),
+            1
+          );
+
+          panAndZoom({
+            fov: {
+              start: currentFov,
+              middle: middleFov,
+              end: initialFov,
+            },
+            position: {
+              start: { ra: currentPosition[0], dec: currentPosition[1] },
+              end: { ra: initialPosition[0], dec: initialPosition[1] },
+            },
+            duration: [zoomOutTime, panTime, zoomInTime],
+            aladin,
+          });
+        }
+      }
+    }
+  };
+
+  return (
+    <IconButton
+      icon={<IconComposer icon="Pin" />}
+      onClick={onClick}
+      disabled={isLoading}
+      text={t("controls.return_to_initial")}
+    />
+  );
+};
+
+ReturnToInital.displayName = "Molecule.ExplorerControl.ReturnToInitial";
+
+export default ReturnToInital;

--- a/components/molecules/ExplorerControls/_styles.scss
+++ b/components/molecules/ExplorerControls/_styles.scss
@@ -5,7 +5,6 @@
 @use "abstracts/functions";
 
 .controls {
-  $controlDim: 40px;
   $controlSpacing: 12px;
 
   .controls-submenu {
@@ -39,15 +38,6 @@
     }
   }
 
-  .wayfinding,
-  .find {
-    > li {
-      + li {
-        margin-top: $controlSpacing;
-      }
-    }
-  }
-
   .pan {
     right: 10px;
     bottom: 0;
@@ -58,14 +48,5 @@
         margin-left: $controlSpacing;
       }
     }
-  }
-
-  .find {
-    position: static;
-  }
-
-  .wayfinding {
-    bottom: calc(50% - #{$controlDim} - (#{$controlSpacing}));
-    left: 0;
   }
 }

--- a/components/molecules/ExplorerControls/index.tsx
+++ b/components/molecules/ExplorerControls/index.tsx
@@ -9,6 +9,7 @@ import ToggleGrid from "./ToggleGrid";
 import ControlStack from "../Controls/Stack";
 import styles from "./styles.module.css";
 import FullscreenToggle from "./FullscreenToggle";
+import ReturnToInital from "./ReturnToInitial";
 
 const ExplorerControls: FC = () => {
   return (
@@ -26,6 +27,7 @@ const ExplorerControls: FC = () => {
       </ControlStack>
       <ControlStack className={styles.viewControls} position="top right">
         <Orientation />
+        <ReturnToInital />
         <ToggleGrid />
       </ControlStack>
     </AladinOverlay>

--- a/components/organisms/Aladin/index.tsx
+++ b/components/organisms/Aladin/index.tsx
@@ -31,8 +31,8 @@ export const Aladin: FunctionComponent<PropsWithChildren<AladinProps>> = ({
   options = {},
   layers,
 }) => {
-  const A = useRef<Aladin | null>(null);
-  const aladin = useRef<AladinInstance | null>(null);
+  const A = useRef<A | null>(null);
+  const aladin = useRef<Aladin | null>(null);
 
   const [hasFocus, setFocus] = useState(false);
   const [isLoading, setLoading] = useState(true);
@@ -55,10 +55,10 @@ export const Aladin: FunctionComponent<PropsWithChildren<AladinProps>> = ({
   const onMounted = useCallback<RefCallback<HTMLDivElement>>((node) => {
     if (node) {
       import("aladin-lite").then((module) => {
-        const global: Aladin = module.default;
+        const global: A = module.default;
 
         global.init.then(() => {
-          const instance: AladinInstance = global.aladin(node, {
+          const instance = global.aladin(node, {
             ...defaultOptions,
             ...options,
           });

--- a/components/organisms/Catalogs/utilities.ts
+++ b/components/organisms/Catalogs/utilities.ts
@@ -20,7 +20,7 @@ export async function getMarkerShape(
   });
 }
 
-export async function addCat(A: Aladin, aladin: AladinInstance, cat: Catalog) {
+export async function addCat(A: A, aladin: Aladin, cat: Catalog) {
   const { path: url, icon, title } = cat;
   const shape: HTMLImageElement | CatalogSourceShape = CUSTOM_SHAPES[title]
     ? await getMarkerShape(CUSTOM_SHAPES[title])
@@ -37,11 +37,7 @@ export async function addCat(A: Aladin, aladin: AladinInstance, cat: Catalog) {
   aladin.addCatalog(catalog);
 }
 
-export const addCats = (
-  A: Aladin,
-  aladin: AladinInstance,
-  catalogs: Array<Catalog>
-) => {
+export const addCats = (A: A, aladin: Aladin, catalogs: Array<Catalog>) => {
   catalogs.forEach((cat) => {
     addCat(A, aladin, cat);
   });

--- a/components/organisms/Embedded/index.tsx
+++ b/components/organisms/Embedded/index.tsx
@@ -6,10 +6,14 @@ import Share from "@/components/molecules/ExplorerControls/Share";
 import OpenCurrentView from "@/components/molecules/ExplorerControls/OpenCurrentView";
 import ControlStack from "@/components/molecules/Controls/Stack";
 import FullscreenToggle from "@/components/molecules/ExplorerControls/FullscreenToggle";
+import ReturnToInital from "@/components/molecules/ExplorerControls/ReturnToInitial";
 
 const EmbeddedExplorer: FunctionComponent = () => {
   return (
     <AladinOverlay space="var(--size-spacing-xs) var(--size-spacing-s) var(--size-spacing-xs) var(--size-spacing-xs)">
+      <ControlStack position="top right">
+        <ReturnToInital />
+      </ControlStack>
       <ControlStack position="bottom left">
         <OpenCurrentView />
         <FullscreenToggle />

--- a/contexts/Aladin.tsx
+++ b/contexts/Aladin.tsx
@@ -1,12 +1,12 @@
 "use client";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect } from "react";
 import { bindAladinEvents } from "@/lib/aladin/helpers";
 
 export interface AladinContext {
   isLoading: false;
   hasFocus: boolean;
-  aladin: AladinInstance;
-  A: Aladin;
+  aladin: Aladin;
+  A: A;
 }
 export interface AladinContextDefault {
   isLoading: true;

--- a/contexts/Tour.tsx
+++ b/contexts/Tour.tsx
@@ -20,7 +20,7 @@ type PoiStep = PoiSteps[number];
 
 interface Transition {
   between: [number | null, number];
-  aladin: AladinInstance;
+  aladin: Aladin;
 }
 
 interface TourContextValue {
@@ -96,7 +96,7 @@ export const TourProvider: FC<PropsWithChildren<TourProviderProps>> = ({
     onComplete,
   }: {
     between: [number, number];
-    aladin: AladinInstance;
+    aladin: Aladin;
     onComplete?: VoidFunction;
   }) => {
     const toIndex = to - 1;

--- a/lib/aladin/animation.ts
+++ b/lib/aladin/animation.ts
@@ -5,11 +5,7 @@ type Position = { ra: number; dec: number };
 
 const isNarrowScreen = () => window.matchMedia("(width < 1130px)").matches;
 
-export const adjustPositionForScreen = ({
-  aladin,
-}: {
-  aladin: AladinInstance;
-}) => {
+export const adjustPositionForScreen = ({ aladin }: { aladin: Aladin }) => {
   if (isNarrowScreen()) {
     const duration =
       parseFloat(
@@ -44,7 +40,7 @@ export const zoom = ({
   start: number;
   end: number;
   duration: number;
-  aladin: AladinInstance;
+  aladin: Aladin;
   onComplete?: () => void;
 }) => {
   let obj = { fov: start };
@@ -70,7 +66,7 @@ export const pan = ({
   start: Position;
   end: Position;
   duration: number;
-  aladin: AladinInstance;
+  aladin: Aladin;
   onComplete?: () => void;
 }) => {
   let obj = start;
@@ -95,7 +91,7 @@ export const panAndZoom = ({
 }: {
   fov: { start: number; end: number; middle: number };
   position: { start: Position; end: Position };
-  aladin: AladinInstance;
+  aladin: Aladin;
   duration: number[];
   onComplete?: () => void;
 }) => {

--- a/lib/aladin/helpers.ts
+++ b/lib/aladin/helpers.ts
@@ -27,7 +27,7 @@ const isAladinCallback = (
 };
 
 export const bindAladinEvents = (
-  aladin: AladinInstance,
+  aladin: Aladin,
   events: ReactAladinCallbacks & AdditionalAladinCallbacks
 ) => {
   Object.keys(events).forEach((eventKey) => {
@@ -41,7 +41,7 @@ export const bindAladinEvents = (
 };
 
 export function getPixelPosition(
-  aladin: AladinInstance,
+  aladin: Aladin,
   { ra, dec }: { ra: number; dec: number }
 ) {
   return Array.from(aladin.world2pix(ra, dec)).reverse();
@@ -75,6 +75,6 @@ export const viewAsParams = ({
   return params;
 };
 
-export const currentViewAsParams = (aladin: AladinInstance) => {
+export const currentViewAsParams = (aladin: Aladin) => {
   return viewAsParams({ fov: aladin.getFov()[0], target: aladin.getRaDec() });
 };

--- a/lib/i18n/localeStrings/en/translation.json
+++ b/lib/i18n/localeStrings/en/translation.json
@@ -74,7 +74,8 @@
     "volume_mute": "Mute audio (m)",
     "volume_unmute": "Unmute audio (m)",
     "fullscreen_open": "Open in fullscreen",
-    "fullscreen_close": "Exit fullscreen"
+    "fullscreen_close": "Exit fullscreen",
+    "return_to_initial": "Return to initial view"
   },
   "menu": {
     "share": {

--- a/types/aladin.d.ts
+++ b/types/aladin.d.ts
@@ -281,7 +281,7 @@ interface GetViewData {
   ): Promise<Blob>;
 }
 
-interface AladinInstance {
+interface Aladin {
   readonly getRaDec: () => [number, number];
   readonly getSize: () => [number, number];
   readonly getFov: () => [number, number];
@@ -398,13 +398,22 @@ interface AladinCatalogOptions {
 
 type AladinCatalogCallback = (sources: AladinSource[]) => void;
 
-interface Aladin {
+interface Coo {
+  setFrame: (frame: CooFrame) => void;
+  distance: (position: Coo) => number;
+  dist2: (position: Coo) => number;
+  equals: (position: Coo) => boolean;
+  format(options: "d" | "s" | "/"): string;
+  format(options: "2"): Array<string>;
+}
+
+interface A {
   /** Initializes the Aladin Lite library, checking for WebGL2 support. This method must be called before instancing an Aladin Lite object. */
   readonly init: Promise<void>;
   readonly aladin: (
     id: string | HTMLElement,
     options?: AladinOptions
-  ) => AladinInstance;
+  ) => Aladin;
   readonly catalog: (options?: AladinCatalogOptions) => AladinCatalog;
   readonly source: (ra: number, dec: number, data: any) => AladinSource;
   // TODO: add option info
@@ -420,6 +429,7 @@ interface Aladin {
   ) => AladinCatalog;
   readonly imageHiPS: (id: string, options?: HiPSOptions) => HiPS;
   readonly HiPS: (id: string, options?: HiPSOptions) => HiPS;
+  readonly coo: (longitude: number, latitude: number, prec: number) => Coo;
   // TODO Add other catalog methods
   // catalogFromSimbad(<target>, <radius-in-degrees>, <catalog-options>?, <successCallback>?)
   // A.catalogFromVizieR(<vizier-cat-id>, <target>, <radius-in-deg>, <cat-options>?, <successCallback>?)
@@ -430,4 +440,10 @@ interface Aladin {
   // A.marker(ra, dec, {popupTitle: <title of the popup>, popupDesc: <text (possibly HTML) for the popup>})
 
   // TODO: Add the final functions
+}
+
+declare module "aladin-lite" {
+  const A: A;
+
+  export default A;
 }

--- a/types/react-aladin.d.ts
+++ b/types/react-aladin.d.ts
@@ -18,7 +18,7 @@ interface ReactAladinCallbacks {
 }
 
 interface AdditionalAladinCallbacks {
-  onLoaded?: (args: { aladin: AladinInstance; A: Aladin }) => void;
+  onLoaded?: (args: { aladin: Aladin; A: A }) => void;
   onFocused?: () => void;
   onBlur?: () => void;
 }


### PR DESCRIPTION
Resolves #210 

Returns to the initial view set from Craft, or search params

- if user has moved away from starting point:
  - if user has reduced motion set, instantly go back
  - if user allows motion, do a zoom and pan with timings based on the current FOV and distance. Maximum 1 second zoom, maximum 1.5 seconds pan