### PR TITLE
feat: removed diagnostics and added new help text

### DIFF
--- a/components/molecules/SonificationControls/HelpPanel/index.tsx
+++ b/components/molecules/SonificationControls/HelpPanel/index.tsx
@@ -137,13 +137,19 @@ const HelpPanel: FC<HelpPanelProps> = ({ buttonClassName, className }) => {
                       <li>
                         {t(
                           "help.step4",
-                          "Use your arrow keys to move in any direction."
+                          "Use your arrow keys, or the WASD keys to move in any direction."
                         )}
                       </li>
                       <li>
                         {t(
                           "help.step5",
                           "Or, click and drag with your mouse or trackpad (or tap and drag on a touchscreen) to explore freely."
+                        )}
+                      </li>
+                      <li>
+                        {t(
+                          "help.step6",
+                          "Scroll your mouse or press the plus (+) and minus (-) buttons to zoom in and out."
                         )}
                       </li>
                     </ul>

--- a/components/organisms/Listener/PointSearcher.js
+++ b/components/organisms/Listener/PointSearcher.js
@@ -373,10 +373,10 @@ class PointSearcher {
     // }
 
     // // Draw nearest neighbours count
-    this.p.fill(255); // White text
-    this.p.textSize(16);
-    this.p.text(`Number of points: ${this.tree.length}`, 20, 150);
-    this.p.text(`queryMag: ${parameters.queryMag}`, 20, 170);
+    // this.p.fill(255); // White text
+    // this.p.textSize(16);
+    // this.p.text(`Number of points: ${this.tree.length}`, 20, 150);
+    // this.p.text(`queryMag: ${parameters.queryMag}`, 20, 170);
     // this.p.text(`Current RA/DEC: ${parameters.currentRaDec}`, 20, 90);
     // this.p.text(`Center Point: ${this.centerPoint}`, 20, 110);
     // this.p.text(`FOV: ${parameters.fov}`, 20, 170);

--- a/components/organisms/Listener/backupPoints.json
+++ b/components/organisms/Listener/backupPoints.json
@@ -6,16 +6,13 @@
       "dec": 8.726624996432312,
       "radius": 11.150919178089264,
       "mag": 17.5,
-      "fov": [
-        10,
-        4.9338624338624335
-      ],
+      "fov": [10, 4.9338624338624335],
       "fovRadius": 5.575459589044632
     }
   },
   "data": {
     "__typename": "Query",
-    "getRangeOfAstroObjects": [
+    "getRangeOfAstroObjectsWithLimit": [
       {
         "RAdeg": 185.2082045461,
         "DECdeg": 8.9786191488,

--- a/components/organisms/Listener/initialPoints.json
+++ b/components/organisms/Listener/initialPoints.json
@@ -6,16 +6,13 @@
       "dec": 8.07268,
       "radius": 2.230183835617853,
       "mag": 19,
-      "fov": [
-        2,
-        0.9867724867724867
-      ],
+      "fov": [2, 0.9867724867724867],
       "fovRadius": 1.1150919178089265
     }
   },
   "data": {
     "__typename": "Query",
-    "getRangeOfAstroObjects": [
+    "getRangeOfAstroObjectsWithLimit": [
       {
         "RAdeg": 189.1555361298,
         "DECdeg": 8.5120440845,

--- a/components/organisms/Listener/utilities.js
+++ b/components/organisms/Listener/utilities.js
@@ -40,10 +40,18 @@ export function controlledWalk(p, aladin) {
   let dx = 0;
   let dy = 0;
 
-  if (p.keyIsDown(p.LEFT_ARROW)) dx -= 1;
-  if (p.keyIsDown(p.RIGHT_ARROW)) dx += 1;
-  if (p.keyIsDown(p.UP_ARROW)) dy -= 1;
-  if (p.keyIsDown(p.DOWN_ARROW)) dy += 1;
+  if (p.keyIsDown(p.LEFT_ARROW) || p.keyIsDown('a')) {
+    dx -= 1;
+  }
+  if (p.keyIsDown(p.RIGHT_ARROW) || p.keyIsDown('d')) {
+    dx += 1;
+  }
+  if (p.keyIsDown(p.UP_ARROW) || p.keyIsDown('w')) {
+    dy -= 1;
+  }
+  if (p.keyIsDown(p.DOWN_ARROW) || p.keyIsDown('s')) {
+    dy += 1;
+  }
 
   // Normalize diagonal movement
   if (dx !== 0 && dy !== 0) {
@@ -126,7 +134,11 @@ export function areArrowsPressed(p) {
     p.keyIsDown(p.LEFT_ARROW) ||
     p.keyIsDown(p.RIGHT_ARROW) ||
     p.keyIsDown(p.UP_ARROW) ||
-    p.keyIsDown(p.DOWN_ARROW)
+    p.keyIsDown(p.DOWN_ARROW) ||
+    p.keyIsDown('w') ||
+    p.keyIsDown('a') ||
+    p.keyIsDown('s') ||
+    p.keyIsDown('d')
   );
 }
 


### PR DESCRIPTION
We've removed the diagnostic text that was on screen, added new text to the help menu and added alternate keys to use instead of the arrow keys.

PointSearcher.js: Removed the on screen text
JSON Files: Renamed the Query name to match the new API name
utilities.js: Added the WASD keys as an alternative to using the arrow keys
HelpPanel/index.tsx: Updated the text to include the alternate movement keys, and explaining how to zoom in and out. We added the tag "help.step6" for the zoom in/out explanation